### PR TITLE
Replace grunt-component with grunt-component-io.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -10,9 +10,9 @@ module.exports = ->
 
     # Browser version building
     component:
-      install:
-        options:
-          action: 'install'
+      default: [ 'lib/**/*' ]
+      options:
+        out: './build/browser/'
     component_build:
       microflo:
         output: './build/browser/'
@@ -112,7 +112,7 @@ module.exports = ->
   # Grunt plugins used for building
   @loadNpmTasks 'grunt-zip'
   @loadNpmTasks 'grunt-contrib-coffee'
-  @loadNpmTasks 'grunt-component'
+  @loadNpmTasks 'grunt-component-io'
   @loadNpmTasks 'grunt-component-build'
   @loadNpmTasks 'grunt-contrib-uglify'
   @loadNpmTasks 'grunt-combine'

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "grunt-cafe-mocha": "~0.1.2",
     "grunt-cli": "~0.1.7",
     "grunt-combine": "~0.8.3",
-    "grunt-component": "~0.1.2",
+    "grunt-component-io": "~0.1.0",
     "grunt-component-build": "~0.2.7",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-coffee": "~0.6.6",


### PR DESCRIPTION
It seems that `grunt-component` was [unpublished](https://github.com/geraintluff/tv4/issues/152) on Aug 25th so I was trying to replace it with `grunt-component-io` to get component dependencies installed. It seems to work.
