### PR TITLE
Remove MsgSetup

### DIFF
--- a/microflo/microflo.cpp
+++ b/microflo/microflo.cpp
@@ -382,13 +382,6 @@ void Network::distributePacket(const Packet &packet, MicroFlo::PortId port) {
     }
 }
 
-void Network::runSetup() {
-    if (state != Running) {
-        return;
-    }
-    distributePacket(Packet(MsgSetup), -1);
-}
-
 void Network::runTick() {
     if (state != Running) {
         return;
@@ -488,8 +481,6 @@ void Network::start() {
     if (notificationHandler) {
         notificationHandler->networkStateChanged(state);
     }
-
-    runSetup();
 }
 
 void Network::stop() {

--- a/microflo/microflo.h
+++ b/microflo/microflo.h
@@ -135,9 +135,8 @@ public:
     Msg type() const { return msg; }
     bool isValid() const { return msg > MsgInvalid && msg < MsgMaxDefined; }
 
-    bool isSetup() const { return msg == MsgSetup; }
     bool isTick() const { return msg == MsgTick; }
-    bool isSpecial() const { return isSetup() || isTick(); }
+    bool isSpecial() const { return isTick(); }
 
     bool isVoid() const { return msg == MsgVoid; }
     bool isStartBracket() const { return msg == MsgBracketStart; }
@@ -256,7 +255,6 @@ public:
     void setIoValue(const uint8_t *buf, uint8_t len);
 
 private:
-    void runSetup();
     void distributePacket(const Packet &packet, MicroFlo::PortId port);
     void processMessages();
 

--- a/microflo/mqtt.hpp
+++ b/microflo/mqtt.hpp
@@ -190,7 +190,6 @@ std::string encodePacket(const Packet &pkg) {
     // internal types
     case MsgMax:
     case MsgMaxDefined:
-    case MsgSetup:
     case MsgTick:
     case MsgInvalid:
         return "Invalid MicroFlo::Packet";

--- a/test/components/DigitalWrite.hpp
+++ b/test/components/DigitalWrite.hpp
@@ -3,24 +3,28 @@ name: DigitalWrite
 description: Write a boolean value to pin
 inports:
   in:
-    type: all
+    type: bool
     description: ""
   pin:
-    type: all
+    type: integer
     description: ""
 outports:
   out:
-    type: all
+    type: bool
     description: ""
 microflo_component */
 class DigitalWrite : public SingleOutputComponent {
+
 public:
+    DigitalWrite()
+        : outPin(-1)
+        , currentState(false)
+    {
+    }
+
     virtual void process(Packet in, MicroFlo::PortId port) {
         using namespace DigitalWritePorts;
-        if (in.isSetup()) {
-            outPin = -1;
-            currentState = false;
-        } else if (port == InPorts::in && in.isBool()) {
+        if (port == InPorts::in && in.isBool()) {
             currentState = in.asBool();
             if (outPin >= 0) {
                 io->DigitalWrite(outPin, currentState);

--- a/test/components/Timer.hpp
+++ b/test/components/Timer.hpp
@@ -3,25 +3,28 @@ name: Timer
 description: "Emit a packet every @interval milliseconds"
 inports:
   interval:
-    type: all
+    type: integer
     description: ""
+    default: 1000
   reset:
-    type: all
+    type: bang
     description: ""
 outports:
   out:
     type: all
     description: ""
+    generating: true
 microflo_component */
 class Timer : public SingleOutputComponent {
 public:
+    Timer()
+        : previousMillis(0)
+        , interval(1000)
+    {}
+
     virtual void process(Packet in, MicroFlo::PortId port) {
         using namespace TimerPorts;
-        if (in.isSetup()) {
-            // defaults
-            previousMillis = 0;
-            interval = 1000;
-        } else if (in.isTick()) {
+        if (in.isTick()) {
             unsigned long currentMillis = io->TimerCurrentMs();
             if (currentMillis - previousMillis >= interval) {
                 previousMillis = currentMillis;

--- a/test/components/ToggleBoolean.hpp
+++ b/test/components/ToggleBoolean.hpp
@@ -1,13 +1,15 @@
 /* microflo_component yaml
 name: ToggleBoolean
-description: Invert output packet everytime an input packet arrives. Output defaults to false
+description: Invert output packet everytime an input packet arrives. First output will be false
 inports:
   in:
-    type: all
+    type: bang
     description: ""
+    triggering: true
   reset:
-    type: all
+    type: bang
     description: ""
+    triggering: true
 outports:
   out:
     type: all
@@ -15,11 +17,14 @@ outports:
 microflo_component */
 class ToggleBoolean : public SingleOutputComponent {
 public:
+    ToggleBoolean()
+        : currentState(true)
+    {}
+
     virtual void process(Packet in, MicroFlo::PortId port) {
         using namespace ToggleBooleanPorts;
-        if (in.isSetup()) {
-            currentState = false;
-        } else if (port == InPorts::in && in.isData()) {
+
+        if (port == InPorts::in) {
             currentState = !currentState;
             send(Packet(currentState));
         } else if (port == InPorts::reset) {


### PR DESCRIPTION
Previously some components would use this to automatically
send a packet on network start. This is an anti-pattern in dataflow/FBP,
and was causing trouble with state being reset on a network:stop/start
cycle