### PR TITLE
Fix invalid FBP protocol messages

### DIFF
--- a/lib/commandstream.coffee
+++ b/lib/commandstream.coffee
@@ -502,8 +502,8 @@ responses.SetIoValueCompleted = () ->
   return m
 responses.SendPacketDone = () ->
   m =
-    protocol: 'microflo'
-    command: 'sendpacketdone'
+    protocol: 'runtime'
+    command: 'packetsent'
     payload: null
   return m
 

--- a/lib/commandstream.coffee
+++ b/lib/commandstream.coffee
@@ -505,7 +505,7 @@ responses.SendPacketDone = (componentLib, graph) ->
     protocol: 'runtime'
     command: 'packetsent'
     payload:
-      #port: 'sssss' # FIXME
+      port: 'sssss' # FIXME
       event: 'data'
       type: 'any'
       graph: graph.name

--- a/lib/commandstream.coffee
+++ b/lib/commandstream.coffee
@@ -307,27 +307,30 @@ toCommandStreamBuffer = (message, componentLib, nodeMap, componentMap, buffer, i
 
 responses = {}
 # Must be named the same as defined in the commands
-responses.NetworkStopped = () ->
+responses.NetworkStopped = (componentLib, graph) ->
   m =
       protocol: "network"
       command: "stopped"
       payload:
+          graph: graph.name
           running: false
           started: false
   return m
-responses.NetworkStarted = () ->
+responses.NetworkStarted = (componentLib, graph) ->
   m = 
     protocol: "network"
     command: "started"
     payload:
+      graph: graph.name
       running: true
       started: true
   return m
-responses.NodesCleared = () ->
+responses.NodesCleared = (componentLib, graph) ->
   m =
     protocol: "graph"
     command: "clear"
-    payload: {}
+    payload:
+      id: graph.name
   return m
 responses.NetworkStatus = (componentLib, graph, cmdData) ->
   running = cmdData.readUInt8(0) == 1
@@ -348,6 +351,7 @@ responses.NodeAdded = (componentLib, graph, cmdData) ->
     payload:
       id: nodeName
       component: component
+      graph: graph.name
   return m
 responses.NodeRemoved = (componentLib, graph, cmdData) ->
   nodeName = nodeNameById(graph.nodeMap, cmdData.readUInt8(1))
@@ -356,6 +360,7 @@ responses.NodeRemoved = (componentLib, graph, cmdData) ->
     command: 'removenode'
     payload:
       id: nodeName
+      graph: graph.name
   return m
 
 responses.NodesConnected = (componentLib, graph, cmdData) ->
@@ -364,6 +369,7 @@ responses.NodesConnected = (componentLib, graph, cmdData) ->
     protocol: 'graph'
     command: 'addedge'
     payload:
+      graph: graph.name
       src:
         node: null
         port: null
@@ -377,6 +383,7 @@ responses.NodesDisconnected = (componentLib, graph, cmdData) ->
     protocol: 'graph'
     command: 'removeedge'
     payload:
+      graph: graph.name
       src:
         node: null
         port: null

--- a/lib/commandstream.coffee
+++ b/lib/commandstream.coffee
@@ -500,11 +500,16 @@ responses.SetIoValueCompleted = () ->
     command: 'setiovaluecompleted'
     payload: null
   return m
-responses.SendPacketDone = () ->
+responses.SendPacketDone = (componentLib, graph) ->
   m =
     protocol: 'runtime'
     command: 'packetsent'
-    payload: null
+    payload:
+      #port: 'sssss' # FIXME
+      event: 'data'
+      type: 'any'
+      graph: graph.name
+      payload: {} # FIXME
   return m
 
 buildResponseMapping = () ->

--- a/lib/runtime.coffee
+++ b/lib/runtime.coffee
@@ -321,7 +321,7 @@ mapMessage = (graph, collector, message)->
             return messages
         else if message.command in ['subscribeedge'] # TODO: make network:edges
           return []
-        else if message.command in ['debugchanged','communicationopen', 'sendpacketdone', 'iovaluechanged']
+        else if message.command in ['debugchanged','communicationopen', 'iovaluechanged']
           console.log 'FBP MICROFLO RESPONSE IGNORED:', message.command if util.debug_protocol
           # ignore
           return []

--- a/lib/runtime.coffee
+++ b/lib/runtime.coffee
@@ -288,6 +288,8 @@ packetSent = (graph, collector, payload) ->
     if not send
         return [] # in the middle of bracketed data, will send when gets to the end
 
+    delete payload.type # XXX
+
     # Check if exported outport
     if graph.outports
         found = null
@@ -300,8 +302,10 @@ packetSent = (graph, collector, payload) ->
             payload:
                 port: found
                 event: 'data'
+                type: 'any'
+                #schema: ''
+                graph: graph.name
                 payload: data
-                index: null
         messages.push m
 
     # Sent network:data for edge introspection

--- a/lib/runtime.coffee
+++ b/lib/runtime.coffee
@@ -288,8 +288,6 @@ packetSent = (graph, collector, payload) ->
     if not send
         return [] # in the middle of bracketed data, will send when gets to the end
 
-    payload.data = data
-
     # Check if exported outport
     if graph.outports
         found = null

--- a/lib/runtime.coffee
+++ b/lib/runtime.coffee
@@ -59,6 +59,7 @@ listComponents = (runtime, connection) ->
             command: "component"
             payload:
                 name: name
+                subgraph: false
                 description: comp.description or ""
                 inPorts: portDefAsArray(componentLib.inputPortsFor(name))
                 outPorts: portDefAsArray(componentLib.outputPortsFor(name))
@@ -75,6 +76,8 @@ sendExportedPorts = (connection, runtime) ->
     ports =
         inPorts: []
         outPorts: []
+        graph: runtime.graph.name
+
     for pub, port of runtime.graph.inports
         ports.inPorts.push
             id: pub

--- a/lib/runtime.coffee
+++ b/lib/runtime.coffee
@@ -126,7 +126,7 @@ handleRuntimeCommand = (command, payload, connection, runtime) ->
         ]
         r =
             type: "microflo"
-            version: "0.4"
+            version: '0.7'
             capabilities: caps
             namespace: runtime.namespace
 

--- a/lib/runtime.coffee
+++ b/lib/runtime.coffee
@@ -614,6 +614,7 @@ class Runtime extends EventEmitter
         @graph.nodeMap = {} # "nodeName" -> { id: numericNodeId }
         @graph.componentMap = {} # "nodeName" -> "componentName"
         @graph.currentNodeId = 1
+        @graph.name = 'default/empty'
 
         @conn =
             send: (response) =>


### PR DESCRIPTION
`fbp-client` enforces no invalid datastructure. This is enough to make fbp-spec pass with https://github.com/flowbased/fbp-spec/pull/144 